### PR TITLE
feat(plugins): add developer mode with dedicated Dev tab

### DIFF
--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -68,6 +68,24 @@ pub struct RegistrySourceConfig {
     pub enabled: Option<bool>,
 }
 
+/// Developer settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeveloperSettings {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dev_plugins_path: Option<String>,
+}
+
+impl Default for DeveloperSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dev_plugins_path: None,
+        }
+    }
+}
+
 /// Full app settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppSettings {
@@ -80,6 +98,8 @@ pub struct AppSettings {
     /// Plugin registry sources (optional, defaults to official registry)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_registries: Option<Vec<RegistrySourceConfig>>,
+    #[serde(default)]
+    pub developer: DeveloperSettings,
 }
 
 impl Default for AppSettings {
@@ -100,6 +120,7 @@ impl Default for AppSettings {
             ui: UiSettings::default(),
             security: SecuritySettings::default(),
             plugin_registries: None,
+            developer: DeveloperSettings::default(),
         }
     }
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -51,6 +51,10 @@ export interface AppSettings {
   security: {
     vaultSetupSkipped: boolean;
   };
+  developer?: {
+    enabled: boolean;
+    devPluginsPath?: string;
+  };
 }
 
 export const defaultSettings: AppSettings = {
@@ -70,6 +74,10 @@ export const defaultSettings: AppSettings = {
   },
   security: {
     vaultSetupSkipped: false,
+  },
+  developer: {
+    enabled: false,
+    devPluginsPath: undefined,
   },
 };
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -462,6 +462,16 @@ export default {
       uninstalling: "Uninstalling...",
       uninstallConfirm: "Are you sure you want to uninstall \"{{name}}\"?",
       uninstallError: "Failed to uninstall plugin",
+      // Developer Mode
+      devModeTitle: "Developer Mode",
+      devModeDesc: "Load plugins directly from a local folder for development",
+      devPathLabel: "Dev plugins path",
+      devPathPlaceholder: "Path to dev plugins folder...",
+      devScan: "Scan",
+      devBadge: "DEV",
+      devNoPath: "Set a dev plugins path to get started",
+      devNoPlugins: "No dev plugins found. Click Scan after setting the path.",
+      tabDev: "Dev",
     },
 
     // --- About section ---

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -456,6 +456,16 @@ export default {
       uninstalling: "Désinstallation...",
       uninstallConfirm: "Êtes-vous sûr de vouloir désinstaller \"{{name}}\" ?",
       uninstallError: "Échec de la désinstallation du plugin",
+      // Mode Développeur
+      devModeTitle: "Mode développeur",
+      devModeDesc: "Charger les plugins directement depuis un dossier local pour le développement",
+      devPathLabel: "Chemin des plugins dev",
+      devPathPlaceholder: "Chemin vers le dossier de plugins dev...",
+      devScan: "Scanner",
+      devBadge: "DEV",
+      devNoPath: "Définissez un chemin de plugins dev pour commencer",
+      devNoPlugins: "Aucun plugin dev trouvé. Cliquez Scanner après avoir défini le chemin.",
+      tabDev: "Dev",
     },
 
     // --- Section À propos ---

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -33,6 +33,7 @@ export interface PluginManifest {
   permissions: string[];
   status: PluginStatus;
   errorMessage?: string;
+  isDev?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
Add a Dev tab in plugin settings to load plugins directly from a local directory without copying. Includes path configuration, scan button, and separate listing of dev plugins with DEV badge. Dev plugins cannot be uninstalled and their manifests are hot-reloaded on re-scan.