### PR TITLE
feat(plugins): session decorator extension point

### DIFF
--- a/src/plugins/PluginAPI.ts
+++ b/src/plugins/PluginAPI.ts
@@ -25,7 +25,7 @@ import type {
   HeaderActionConfig,
   HeaderActionHandle,
 } from './types';
-import type { SidebarViewRegistration, SidebarSectionRegistration, SettingsPanelRegistration, ContextMenuItemConfig, QuickConnectSectionRegistration } from './extensionTypes';
+import type { SidebarViewRegistration, SidebarSectionRegistration, SettingsPanelRegistration, ContextMenuItemConfig, QuickConnectSectionRegistration, SessionDecoratorRegistration } from './extensionTypes';
 
 /**
  * Check if a plugin has a specific permission
@@ -58,6 +58,8 @@ export function createPluginAPI(
     onContextMenuItemUnregister: (pluginId: string, itemId: string) => void;
     onQuickConnectSectionRegister: (pluginId: string, section: QuickConnectSectionRegistration) => void;
     onQuickConnectSectionUnregister: (pluginId: string, sectionId: string) => void;
+    onSessionDecoratorRegister: (pluginId: string, decorator: SessionDecoratorRegistration) => void;
+    onSessionDecoratorUnregister: (pluginId: string, decoratorId: string) => void;
     onAddStatusBarItem: (pluginId: string, config: StatusBarItemConfig) => StatusBarItemHandle;
     onAddHeaderAction: (pluginId: string, config: HeaderActionConfig) => HeaderActionHandle;
     getSessions: () => SessionInfo[];
@@ -172,6 +174,21 @@ export function createPluginAPI(
     unregisterQuickConnectSection(sectionId: string) {
       pluginState.quickConnectSections.delete(sectionId);
       callbacks.onQuickConnectSectionUnregister(pluginId, sectionId);
+    },
+
+    // Session decorators
+    registerSessionDecorator(config: SessionDecoratorRegistration) {
+      if (!hasPermission(permissions, 'ui_session_decorator')) {
+        console.warn(`[Plugin ${pluginId}] Missing permission: ui_session_decorator`);
+        return;
+      }
+      pluginState.sessionDecorators.set(config.config.id, config);
+      callbacks.onSessionDecoratorRegister(pluginId, config);
+    },
+
+    unregisterSessionDecorator(decoratorId: string) {
+      pluginState.sessionDecorators.delete(decoratorId);
+      callbacks.onSessionDecoratorUnregister(pluginId, decoratorId);
     },
 
     // Commands

--- a/src/plugins/extensionTypes.ts
+++ b/src/plugins/extensionTypes.ts
@@ -298,6 +298,36 @@ export interface QuickConnectSectionRegistration {
 }
 
 // ============================================================================
+// Session Decorator Extension Types
+// ============================================================================
+
+/**
+ * Configuration for a session decorator registered by a plugin.
+ * Decorators render visual elements (e.g., tag pills) into session cards.
+ */
+export interface SessionDecoratorConfig {
+  /** Unique decorator identifier */
+  id: string;
+  /** Sort order (lower = rendered first) */
+  order?: number;
+}
+
+/**
+ * Registration object for a session decorator
+ */
+export interface SessionDecoratorRegistration {
+  /** Decorator configuration */
+  config: SessionDecoratorConfig;
+  /**
+   * Render function called for each session card
+   * @param sessionId - The session's unique ID
+   * @param container - DOM element to render into
+   * @returns Optional cleanup function called on unmount
+   */
+  render: (sessionId: string, container: HTMLElement) => void | (() => void);
+}
+
+// ============================================================================
 // Toolbar Extension Types
 // ============================================================================
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -4,10 +4,10 @@
  * API v1 - Unified types for backend and frontend plugin system
  */
 
-import type { SidebarSectionRegistration, SidebarViewRegistration, SettingsPanelRegistration, ContextMenuItemConfig, StatusBarItemConfig, StatusBarItemHandle, HeaderActionConfig, HeaderActionHandle, QuickConnectSectionRegistration } from './extensionTypes';
+import type { SidebarSectionRegistration, SidebarViewRegistration, SettingsPanelRegistration, ContextMenuItemConfig, StatusBarItemConfig, StatusBarItemHandle, HeaderActionConfig, HeaderActionHandle, QuickConnectSectionRegistration, SessionDecoratorRegistration } from './extensionTypes';
 
 // Re-export extension types
-export type { SidebarSectionRegistration, SidebarViewRegistration, SettingsPanelRegistration, ContextMenuItemConfig, StatusBarItemConfig, StatusBarItemHandle, HeaderActionConfig, HeaderActionHandle, QuickConnectSectionRegistration } from './extensionTypes';
+export type { SidebarSectionRegistration, SidebarViewRegistration, SettingsPanelRegistration, ContextMenuItemConfig, StatusBarItemConfig, StatusBarItemHandle, HeaderActionConfig, HeaderActionHandle, QuickConnectSectionRegistration, SessionDecoratorRegistration } from './extensionTypes';
 export type { ContextMenuContext } from './extensionTypes';
 
 // ============================================================================
@@ -75,6 +75,7 @@ export type Permission =
   | 'ui_sidebar'
   | 'ui_context_menu'
   | 'ui_quick_connect'
+  | 'ui_session_decorator'
   // Terminal
   | 'terminal_read'
   | 'terminal_write'
@@ -205,6 +206,10 @@ export interface SimplyTermPluginAPI {
   registerQuickConnectSection(config: QuickConnectSectionRegistration): void;
   unregisterQuickConnectSection(sectionId: string): void;
 
+  // Session decorators (requires ui_session_decorator)
+  registerSessionDecorator(config: SessionDecoratorRegistration): void;
+  unregisterSessionDecorator(decoratorId: string): void;
+
   // Commands (requires ui_commands)
   registerCommand(config: CommandRegistration): void;
   executeCommand(commandId: string): void;
@@ -297,6 +302,7 @@ export interface LoadedPlugin {
   settingsPanels: Map<string, SettingsPanelRegistration>;
   contextMenuItems: Map<string, ContextMenuItemConfig>;
   quickConnectSections: Map<string, QuickConnectSectionRegistration>;
+  sessionDecorators: Map<string, SessionDecoratorRegistration>;
   subscriptions: Unsubscribe[];
   onLoadCallback?: () => void;
   onUnloadCallback?: () => void;
@@ -329,6 +335,8 @@ export type PluginEvent =
   | { type: 'context-menu:unregister'; pluginId: string; itemId: string }
   | { type: 'quick-connect:register'; pluginId: string; sectionId: string }
   | { type: 'quick-connect:unregister'; pluginId: string; sectionId: string }
+  | { type: 'session-decorator:register'; pluginId: string; decoratorId: string }
+  | { type: 'session-decorator:unregister'; pluginId: string; decoratorId: string }
   | { type: 'statusbar:changed' }
   | { type: 'headeractions:changed' };
 


### PR DESCRIPTION
## Summary
- New plugin extension point `registerSessionDecorator` allowing plugins to inject visual elements into session cards
- Tags plugin uses it to render colored tag pills on sessions in the sidebar
- Full lifecycle: permission check (`ui_session_decorator`), register/unregister, cleanup on plugin unload

## Test plan
- [ ] Create tags in Settings > Tags
- [ ] Right-click session > Manage Tags > assign tags
- [ ] Colored tag pills appear on the session card
- [ ] Remove a tag → pill disappears
- [ ] Delete a tag definition → removed from all cards