### PR TITLE
fix(ci): pin GitHub Actions to full commit SHA hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,23 +39,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # --- Windows + GitHub-hosted setup ---
       - name: Setup Node.js
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
 
       - name: Setup Rust
         if: matrix.os == 'windows-latest'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Rust cache
         if: matrix.os == 'windows-latest'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
         with:
           workspaces: src-tauri
 
@@ -92,7 +92,7 @@ jobs:
         run: npm ci
 
       - name: Build and release Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Pin all 5 GitHub Actions to their full commit SHA instead of mutable tags
- Resolves SonarCloud security hotspot `githubactions:S7637`

| Action | Before | After (SHA) |
|--------|--------|-------------|
| actions/checkout | v4 | 34e11487... |
| actions/setup-node | v4 | 49933ea5... |
| dtolnay/rust-toolchain | stable | 4be9e76f... |
| Swatinem/rust-cache | v2 | ad397744... |
| tauri-apps/tauri-action | v0 | 79c62484... |

## Test plan

- [ ] SonarCloud security hotspot should be resolved
- [ ] Build workflow still functions correctly