### PR TITLE
release: SimplyTerm v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplyterm",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplyterm",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplyterm",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A modern, fast, cross-platform terminal",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplyterm"
-version = "0.5.0"
+version = "0.6.0"
 description = "A modern, fast, cross-platform terminal"
 authors = ["SimplyTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SimplyTerm",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.simplyterm.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## SimplyTerm v0.6.0

### New Features
- **SFTP Connection Pool** — persistent SSH sessions, no more reconnection per click
- **Drag & Drop Upload** — drop files from OS directly into SFTP browser
- **File Download** — native Save As dialog for downloading remote files
- **Recursive Delete** — delete folders with contents
- **Copy Path** — copy remote file/folder path to clipboard
- **Drag to Subfolder** — move files between folders via drag & drop
- **Hidden Files Toggle** — show/hide dotfiles, persisted across sessions
- **Colored File Icons** — file icons colored by extension type
- **Complete i18n** — full French/English SFTP translations

### Fixes & Improvements
- Fix pane split causing SFTP reconnection
- Fix context menu positioning (CSS transform offset)
- Pin GitHub Actions to commit SHAs (security)
- SonarCloud exclusions for generated schemas and i18n files
- Add terser for production builds
- Remove unused Rust imports