### PR TITLE
fix(ci): add missing libudev-dev for Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libudev-dev
 
       # --- macOS: Import Apple Developer Certificate ---
       - name: Import Apple Developer Certificate


### PR DESCRIPTION
## Summary
- Add `libudev-dev` to the Linux system dependencies in the CI workflow
- This was lost during the merge of PR #23 (the fix commit wasn't included in the squash)

## Test plan
- [ ] Trigger Build workflow after merge
- [ ] Verify Linux job compiles successfully (no more `libudev-sys` build failure)