### PR TITLE
fix(ci): add virtual display (xvfb) for Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libudev-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libudev-dev xvfb
+
+      - name: Setup virtual display
+        if: runner.os == 'Linux'
+        run: |
+          Xvfb :99 -screen 0 1024x768x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
 
       # --- macOS: Import Apple Developer Certificate ---
       - name: Import Apple Developer Certificate


### PR DESCRIPTION
## Summary
- Install `xvfb` and start a virtual display (`:99`) before the Tauri build on Linux
- WebKitGTK requires a display server even for bundling, which headless CI runners don't have

## Root cause
Build failed with: `Could not create default EGL display: EGL_BAD_PARAMETER`
This commit was pushed to PR #25 after it was already merged.

## Test plan
- [ ] Linux build should pass without EGL errors